### PR TITLE
Preserve @rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function normalizeSelectors(rule) {
   selectors.sort()
 
   return selectors
-      .map(selector => (rule.parent.type === 'atrule' ? `@${rule.parent.name}.${rule.parent.params}` : selector)
+      .map(selector => (rule.parent.type === 'atrule' ? `@${rule.parent.name}.${rule.parent.params}.${selector}` : selector)
       .replace(/'/g, '"')
       .replace(/::(before|after)/g, ':$1')
       .replace(/\[(.+)=['"]?([a-zA-Z_-]+?)['"]?\]/g, '[$1=$2]')

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function normalizeSelectors(rule) {
   selectors.sort()
 
   return selectors
-    .map(selector => selector
+      .map(selector => (rule.parent.type === 'atrule' ? `@${rule.parent.name}.${rule.parent.params}` : selector)
       .replace(/'/g, '"')
       .replace(/::(before|after)/g, ':$1')
       .replace(/\[(.+)=['"]?([a-zA-Z_-]+?)['"]?\]/g, '[$1=$2]')


### PR DESCRIPTION
Currently, directives in @-rules are stripped out. The following styles:
```css
@keyframes pulse {
  from {
    opacity: 0.5;
  }

  to {
    opacity: 1;
  }
}
```

Leads to these output styles:
```css
@keyframes pulse {}
```

By prefixing selectors inside @ rules (e.g. keyframes), this prevents override styles from being removed.